### PR TITLE
feat: add logo image and align branding

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <header>
   <div class="wrap brand">
     <a href="{{ '/' | relative_url }}" aria-label="홈으로">
-      <span class="logo" aria-hidden="true"></span>
+      <img class="logo" src="{{ '/assets/img/logo-opt.png' | relative_url }}" alt="해성골재건기 로고">
     </a>
     <strong>(주)해성골재건기</strong>
   </div>

--- a/styles.css
+++ b/styles.css
@@ -6,7 +6,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Noto Sans K
 header{position:sticky;top:0;backdrop-filter:saturate(1.2) blur(6px);background:rgba(255,255,255,.85);border-bottom:1px solid #eee;z-index:10}
 .wrap{max-width:960px;margin:0 auto;padding:16px}
 .brand{display:flex;align-items:center;gap:10px}
-.brand .logo{width:36px;height:36px;border-radius:10px;background:var(--brand);display:inline-block}
+ .brand .logo{width:36px;height:36px;border-radius:10px;display:block}
 nav a{margin-right:12px;text-decoration:none;color:#333}
 nav a.active{font-weight:700}
 .hero{padding:48px 16px 24px;background:linear-gradient(180deg,rgba(10,124,255,.06),transparent)}


### PR DESCRIPTION
## Summary
- replace placeholder header logo with uploaded image
- tweak CSS so logo and title align horizontally

## Testing
- `bundle exec jekyll build` *(fails: command not found: jekyll)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68a2dad6d74083228250d45e126e4fab